### PR TITLE
disconnect_client 반환 데이터 보충(다음 운동 세트 전송)

### DIFF
--- a/app/ai/ai_model.py
+++ b/app/ai/ai_model.py
@@ -2,8 +2,8 @@ from tensorflow.keras.models import load_model
 import numpy as np
 
 # 앱 시작 시 모델 한 번만 로드
-fall_model = load_model(r"C:\Users\okqkf\OneDrive\Desktop\Lecture\25-1\캡스톤디자인\PoseSync-Flask\app\ai\fall_detection_model_v2.h5") # 진우
-# fall_model = load_model(r"c:\new_pose_sync\app\ai\fall_detection_model_v2.h5") # 성재
+# fall_model = load_model(r"C:\Users\okqkf\OneDrive\Desktop\Lecture\25-1\캡스톤디자인\PoseSync-Flask\app\ai\fall_detection_model_v2.h5") # 진우
+fall_model = load_model(r"c:\new_pose_sync\app\ai\fall_detection_model_v2.h5") # 성재
 # retracing 방지를 위한 초기 더미 예측
 fall_model.predict(np.zeros((1, 30, 6)))
 

--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@ from app.models import db, User  # models/__init__.py에서 정의한 db
 import config
 from sqlalchemy import inspect
 from app.controllers.user_controller import save_body_data, body_data_bp
-from app.services.user_info_service import save_phone_number_and_height, save_exercise_set_service, get_exercise_set_service, is_user_exist
+from app.services.user_info_service import save_phone_number_and_height, save_exercise_set_service, get_exercise_set_service, is_user_exist, get_next_exercise_set
 from app.models.exercise_set import ExerciseSet
 
 from app.models.user import User
@@ -45,6 +45,30 @@ register_user_socket(socketio)
 @app.route('/')
 def home():
     return 'Flask + SQLAlchemy + MySQL + WebSocket 실행 중!'
+
+@app.route('/test', methods=['GET'])
+def test():
+    id = request.args.get('id')
+    exercise_set = get_next_exercise_set(int(id))
+    
+    if exercise_set:
+        result = {
+            "id": exercise_set.id,
+            "user_id": exercise_set.user_id,
+            "exercise_type": exercise_set.exercise_type,
+            "exercise_weight": exercise_set.exercise_weight,
+            "target_count": exercise_set.target_count,
+            "current_count": exercise_set.current_count,
+            "is_finished": exercise_set.is_finished,
+            "is_success": exercise_set.is_success,
+            "routine_group": exercise_set.routine_group,
+            "created_at": exercise_set.created_at.isoformat() if exercise_set.created_at else None,
+            "updated_at": exercise_set.updated_at.isoformat() if exercise_set.updated_at else None
+        }
+        return jsonify(result), 200
+    else:
+        return jsonify({"error": "No data"}), 400
+
 
 # 전화번호와 키로 User 생성하는 API
 @app.route('/create_user', methods=['POST'])


### PR DESCRIPTION
## 📝 작업 내용
> 현재 운동이 끝난 후, 다음 운동 데이터 전송


## 🔍 테스트 방법
> 이 API 테스트는 단순 기능 테스트이므로 실제 서비스에서 소켓 반환 데이터와는 양식이 다름!
> http://127.0.0.1:5001/test?id=75 (다음 운동 데이터가 있을 경우)
![image](https://github.com/user-attachments/assets/9280b7be-b42a-4df8-bdbb-200fade5c9d0)
> http://127.0.0.1:5001/test?id=77 (현재 운동이 마지막, 즉 다음 운동 데이터가 없을 경우)
![image](https://github.com/user-attachments/assets/905975e8-be0b-45d7-8f07-4342a11f9d0f)
